### PR TITLE
Make MMRead treat data folder as Immutable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ cmake-build-debug*
 CMakeFiles*
 *~
 
+build*
 */build/*
 **/.venv/*
 

--- a/src/test/test_MMRead.c
+++ b/src/test/test_MMRead.c
@@ -477,7 +477,6 @@ void test_MMWrite (void)
         // write the matrix to the data/comments_*.mtx file
         //----------------------------------------------------------------------
 
-        // snprintf (filename, LEN, LG_DATA_DIR "comments_%s", aname) ;
         rewind (fcomments) ;
         FILE *foutput = tmpfile ( ) ;
         TEST_CHECK (foutput != NULL) ;


### PR DESCRIPTION
`test_MMRead` contains a subtest that (strangely) test `MMWrite`. That test seems to modify the `comments.txt` and `comments_*.mtx` files. At the end of `test_MMRead` those files go back to how they were checked into the repository but that means that a failure in `test_MMRead` can drag on ghost failures in other tests (specifically observed in `test_minmax`). If `test_MMRead` passes all is well, but if it doesn't it can be pretty weird... 

This PR changes the test to write to temp files, opened `r/w` with `tmpfile()` and rewinded instead of opened separately for write then read.

The total effect is not changing the data directory and remove this spurious effect. 

I also added `build*` to `.gitignore` since we build in `build_lc` and it makes the git diff... irritating... 